### PR TITLE
Cache priming tests

### DIFF
--- a/src/pytest_codspeed/_wrapper/.gitignore
+++ b/src/pytest_codspeed/_wrapper/.gitignore
@@ -1,1 +1,2 @@
 dist_callgrind_wrapper.*
+build.lock

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -349,6 +349,7 @@ def test_pytest_xdist_concurrency_compatibility(
 
 
 @skip_without_valgrind
+@skip_with_pytest_benchmark
 def test_benchmark_marker_tmp_path(pytester: pytest.Pytester, codspeed_env) -> None:
     pytester.makepyfile(
         """
@@ -365,6 +366,7 @@ def test_benchmark_marker_tmp_path(pytester: pytest.Pytester, codspeed_env) -> N
 
 
 @skip_without_valgrind
+@skip_with_pytest_benchmark
 def test_benchmark_fixture_tmp_path(pytester: pytest.Pytester, codspeed_env) -> None:
     pytester.makepyfile(
         """
@@ -382,6 +384,7 @@ def test_benchmark_fixture_tmp_path(pytester: pytest.Pytester, codspeed_env) -> 
 
 
 @skip_without_valgrind
+@skip_with_pytest_benchmark
 def test_benchmark_fixture_warmup(pytester: pytest.Pytester, codspeed_env) -> None:
     pytester.makepyfile(
         """

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -348,6 +348,7 @@ def test_pytest_xdist_concurrency_compatibility(
         result.stdout.fnmatch_lines(["*256 passed*"])
 
 
+@skip_without_valgrind
 def test_benchmark_marker_tmp_path(pytester: pytest.Pytester, codspeed_env) -> None:
     pytester.makepyfile(
         """
@@ -363,6 +364,7 @@ def test_benchmark_marker_tmp_path(pytester: pytest.Pytester, codspeed_env) -> N
     assert result.ret == 0, "the run should have succeeded"
 
 
+@skip_without_valgrind
 def test_benchmark_fixture_tmp_path(pytester: pytest.Pytester, codspeed_env) -> None:
     pytester.makepyfile(
         """
@@ -379,6 +381,7 @@ def test_benchmark_fixture_tmp_path(pytester: pytest.Pytester, codspeed_env) -> 
     assert result.ret == 0, "the run should have succeeded"
 
 
+@skip_without_valgrind
 def test_benchmark_fixture_warmup(pytester: pytest.Pytester, codspeed_env) -> None:
     pytester.makepyfile(
         """


### PR DESCRIPTION
With Python 3.12 pytest-codspeed runs the benchmark twice. Once to prime the cache and once with instrumentation enabled.

The tests added here are derived from the discussion in #25.