### PR TITLE
[WIP] Alternative fix for `stdout`/`stderr` redirects

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,4 +16,5 @@ repos:
     rev: v0.3.3
     hooks:
       - id: ruff
+        args: [--fix]
       - id: ruff-format

--- a/src/pytest_codspeed/_wrapper/.gitignore
+++ b/src/pytest_codspeed/_wrapper/.gitignore
@@ -1,1 +1,2 @@
 dist_callgrind_wrapper.*
+build.lock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,3 +37,9 @@ skip_without_perf_trampoline = pytest.mark.skipif(
 skip_with_perf_trampoline = pytest.mark.skipif(
     IS_PERF_TRAMPOLINE_SUPPORTED, reason="perf trampoline is supported"
 )
+
+IS_PYTEST_XDIST_INSTALLED = importlib.util.find_spec("pytest_xdist") is not None
+skip_without_pytest_xdist = pytest.mark.skipif(
+    not IS_PYTEST_XDIST_INSTALLED,
+    reason="pytest_xdist not installed",
+)

--- a/tests/examples/test_addition_fixture.py
+++ b/tests/examples/test_addition_fixture.py
@@ -1,4 +1,4 @@
 def test_some_addition_performance(benchmark):
     @benchmark
     def _():
-        return 1 + 1
+        assert 1 + 1


### PR DESCRIPTION
An alternative to #25.

Benefits (?) of this implementation:
- for tests marked as benchmarks (no fixture), the cache priming doesn't result in the same scope being run twice, e.g. the following works now:
    ```python
    @pytest.mark.benchmark
    def test_tmp_path(tmp_path):
        (tmp_path / "random").mkdir()
    ```
    this is accomplished via code borrowed from `pytest-rerunfailures`, see `pytest_codspeed.plugin.prime_cache`

Submitting to see benchmark results.