### PR TITLE
[WIP] Don't override pytest's default protocol

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,4 +16,5 @@ repos:
     rev: v0.3.3
     hooks:
       - id: ruff
+        args: [--fix]
       - id: ruff-format

--- a/src/pytest_codspeed/_wrapper/.gitignore
+++ b/src/pytest_codspeed/_wrapper/.gitignore
@@ -1,1 +1,2 @@
 dist_callgrind_wrapper.*
+build.lock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,3 +37,9 @@ skip_without_perf_trampoline = pytest.mark.skipif(
 skip_with_perf_trampoline = pytest.mark.skipif(
     IS_PERF_TRAMPOLINE_SUPPORTED, reason="perf trampoline is supported"
 )
+
+IS_PYTEST_XDIST_INSTALLED = importlib.util.find_spec("pytest_xdist") is not None
+skip_without_pytest_xdist = pytest.mark.skipif(
+    not IS_PYTEST_XDIST_INSTALLED,
+    reason="pytest_xdist not installed",
+)


### PR DESCRIPTION
Another alternative to #25 

This time we leave original implementation as is and rather correct the implementation to not override the default protocol.