### PR TITLE
docs(readme): update action version in the CI workflow configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v2
+        uses: CodSpeedHQ/action@v3
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: pytest tests/ --codspeed


### PR DESCRIPTION
Hey there,

Following up on https://github.com/CodSpeedHQ/action/issues/112, this PR updates the README to point to the latest stable version of the action. I followed the snippet to configure my workflow, and ended up getting a warning from the action suggesting to update.

Let me know if you have any comment!