### PR TITLE
Fix some of the typing broken in #81

### DIFF
--- a/src/pytest_codspeed/plugin.py
+++ b/src/pytest_codspeed/plugin.py
@@ -30,11 +30,12 @@ from pytest_codspeed.utils import (
 from . import __version__
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, TypeVar
+    from typing import Any, Callable, ParamSpec, TypeVar
 
     from pytest_codspeed.instruments import Instrument
 
     T = TypeVar("T")
+    P = ParamSpec("P")
 
 
 @pytest.hookimpl(trylast=True)
@@ -328,9 +329,7 @@ class BenchmarkFixture:
         self._plugin = get_plugin(self._config)
         self._called = False
 
-    def __call__(
-        self, target: Callable[P, T], *args: P.args, **kwargs: P.kwargs
-    ) -> T:
+    def __call__(self, target: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         if self._called:
             raise RuntimeError("The benchmark fixture can only be used once per test")
         self._called = True

--- a/src/pytest_codspeed/plugin.py
+++ b/src/pytest_codspeed/plugin.py
@@ -329,7 +329,7 @@ class BenchmarkFixture:
         self._called = False
 
     def __call__(
-        self, target: Callable[..., T], *args: tuple, **kwargs: dict[str, Any]
+        self, target: Callable[P, T], *args: P.args, **kwargs: P.kwargs
     ) -> T:
         if self._called:
             raise RuntimeError("The benchmark fixture can only be used once per test")


### PR DESCRIPTION
See https://github.com/CodSpeedHQ/pytest-codspeed/pull/81#discussion_r2198658026

I don’t know which other public APIs’ typing were broken by that PR. Maybe you should run a type checker in CI to avoid breakage like this.