### PR TITLE
fix args/kwargs type annotations

### DIFF
--- a/src/pytest_codspeed/instruments/__init__.py
+++ b/src/pytest_codspeed/instruments/__init__.py
@@ -31,8 +31,8 @@ class Instrument(metaclass=ABCMeta):
         name: str,
         uri: str,
         fn: Callable[..., T],
-        *args: tuple,
-        **kwargs: dict[str, Any],
+        *args: Any,
+        **kwargs: Any,
     ) -> T: ...
 
     @abstractmethod

--- a/src/pytest_codspeed/instruments/valgrind.py
+++ b/src/pytest_codspeed/instruments/valgrind.py
@@ -53,8 +53,8 @@ class ValgrindInstrument(Instrument):
         name: str,
         uri: str,
         fn: Callable[..., T],
-        *args: tuple,
-        **kwargs: dict[str, Any],
+        *args: Any,
+        **kwargs: Any,
     ) -> T:
         self.benchmark_count += 1
 

--- a/src/pytest_codspeed/instruments/walltime.py
+++ b/src/pytest_codspeed/instruments/walltime.py
@@ -188,8 +188,8 @@ class WallTimeInstrument(Instrument):
         name: str,
         uri: str,
         fn: Callable[..., T],
-        *args: tuple,
-        **kwargs: dict[str, Any],
+        *args: Any,
+        **kwargs: Any,
     ) -> T:
         benchmark_config = BenchmarkConfig.from_codspeed_config_and_marker_data(
             self.config, marker_options

--- a/src/pytest_codspeed/plugin.py
+++ b/src/pytest_codspeed/plugin.py
@@ -267,7 +267,7 @@ def wrap_runtest(
     fn: Callable[..., T],
 ) -> Callable[..., T]:
     @functools.wraps(fn)
-    def wrapped(*args: tuple, **kwargs: dict[str, Any]) -> T:
+    def wrapped(*args: Any, **kwargs: Any) -> T:
         return _measure(plugin, node, config, None, fn, args, kwargs)
 
     return wrapped
@@ -329,7 +329,7 @@ class BenchmarkFixture:
         self._called = False
 
     def __call__(
-        self, target: Callable[..., T], *args: tuple, **kwargs: dict[str, Any]
+        self, target: Callable[..., T], *args: Any, **kwargs: Any
     ) -> T:
         if self._called:
             raise RuntimeError("The benchmark fixture can only be used once per test")


### PR DESCRIPTION
This fixes the type annotations for `*args, **kwargs` in a number of places, where `*args: tuple, **kwargs: dict[str, Any]` was being used.  That implies that the *value* of every arg is a tuple and the *value* of every kwarg is a dict (not just that `args` itself will become a tuple and `kwargs` itself will become a dict)  which is likely not what was intended.
