### PR TITLE
Pin python in ci integration tests to prevent intermitent codspeed segfaults in walltime

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  PYTHON_VERSION: "3.14"
+  PYTHON_VERSION: "3.14.2"
   SHARDS: 4
 
 jobs:


### PR DESCRIPTION
All observed crashes occured with `3.14.3`, although it did not crash all the time.
Pin for now to unblock other PRs, and investigate later