### PR TITLE
feat(hooks): declare native extension free-thread safe

### DIFF
--- a/src/pytest_codspeed/instruments/hooks/instrument_hooks_module.c
+++ b/src/pytest_codspeed/instruments/hooks/instrument_hooks_module.c
@@ -297,5 +297,9 @@ PyMODINIT_FUNC PyInit_dist_instrument_hooks(void) {
     PyModule_AddIntConstant(module, "MARKER_TYPE_BENCHMARK_START", MARKER_TYPE_BENCHMARK_START);
     PyModule_AddIntConstant(module, "MARKER_TYPE_BENCHMARK_END", MARKER_TYPE_BENCHMARK_END);
 
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
     return module;
 }


### PR DESCRIPTION
Declare the `dist_instrument_hooks` native extension as supporting the
free-threaded build, silencing the runtime warning emitted when the module is
imported on a free-threaded interpreter (e.g. 3.13t/3.14t/3.15t).

Without this declaration, CPython re-enables the GIL on import and prints:

> RuntimeWarning: The global interpreter lock (GIL) has been enabled to load
> module 'pytest_codspeed.instruments.hooks.dist_instrument_hooks', which has
> not declared that it can run safely without the GIL.

The underlying `instrument-hooks` C library uses its own internal locking
(`os_unfair_lock` / mutex), so the module is safe to run without the GIL. The
`PyUnstable_Module_SetGIL` call is guarded by `#ifdef Py_GIL_DISABLED` so it has
no effect on standard (GIL-enabled) builds.