### PR TITLE
build: enable free-threaded wheels in cibuildwheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,9 @@ jobs:
         with:
           submodules: true
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.1
+        # Pinned to main past v3.4.1 for CPython 3.15 beta support (PR #2833).
+        # Revisit once the next tagged release ships 3.15 metadata.
+        uses: pypa/cibuildwheel@ec0977e5f64e2ec8c1276eea62083c103613b756
         env:
           CIBW_ARCHS: ${{ matrix.platform.arch }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           submodules: true
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_ARCHS: ${{ matrix.platform.arch }}
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ push = false
 
 [tool.cibuildwheel]
 build = "cp*{manylinux,macosx}*"
-enable = ["cpython-freethreading", "cpython-prerelease"]
+enable = ["cpython-prerelease"]
 test-extras = ["build", "test", "compat"]
 test-command = "pytest -v --ignore={project}/tests/benchmarks {project}/tests"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Software Development :: Testing",
     "Topic :: System :: Benchmark",
     "Topic :: Utilities",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ push = false
 
 [tool.cibuildwheel]
 build = "cp*{manylinux,macosx}*"
+enable = ["cpython-freethreading"]
 test-extras = ["build", "test", "compat"]
 test-command = "pytest -v --ignore={project}/tests/benchmarks {project}/tests"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ push = false
 
 [tool.cibuildwheel]
 build = "cp*{manylinux,macosx}*"
-enable = ["cpython-freethreading"]
+enable = ["cpython-freethreading", "cpython-prerelease"]
 test-extras = ["build", "test", "compat"]
 test-command = "pytest -v --ignore={project}/tests/benchmarks {project}/tests"
 


### PR DESCRIPTION
Opt cibuildwheel into building free-threaded CPython wheels so the
`dist_instrument_hooks` native extension actually ships for 3.13t / 3.14t /
3.15t.

cibuildwheel does not build free-threaded wheels by default, even when the
`build` pattern matches `cp*`. Without the opt-in, users on free-threaded
interpreters fell back to a pure-Python install with no compiled extension and
saw at runtime:

> Failed to initialize instrument hooks: Failed to load instrument hooks
> library: cannot import name 'dist_instrument_hooks' from
> 'pytest_codspeed.instruments.hooks'

Pairs with #120 (which declares the extension free-thread safe so the GIL stays
disabled on import).