### PR TITLE
ci: add import-time benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -43,9 +43,33 @@ jobs:
           mode: ${{ matrix.mode }}
           run: uv run pytest tests/benchmarks/ --codspeed --test-group=${{ matrix.shard }} --test-group-count=${{ env.SHARDS }}
 
+  import-benchmarks:
+    strategy:
+      matrix:
+        mode: ["simulation", "walltime"]
+
+    name: "Run import-time benchmarks (${{ matrix.mode }})"
+    runs-on: ${{ matrix.mode == 'walltime' && 'codspeed-macro' || 'ubuntu-24.04' }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: "recursive"
+      - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install local version of pytest-codspeed
+        run: uv sync --dev
+      - name: Run import-time benchmarks
+        uses: CodSpeedHQ/action@main
+        with:
+          mode: ${{ matrix.mode }}
+          config: codspeed-import-time.yml
+
   all-checks:
     runs-on: ubuntu-latest
     steps:
       - run: echo "All CI checks passed."
     needs:
       - benchmarks
+      - import-benchmarks

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -32,11 +32,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install local version of pytest-codspeed
-        run: |
-          sudo apt-get update
-          sudo apt-get install valgrind -y
-          uv sync --dev
-          sudo apt-get remove valgrind -y
+        run: uv sync --dev
       - name: Run benchmarks
         uses: CodSpeedHQ/action@main
         with:

--- a/codspeed-import-time.yml
+++ b/codspeed-import-time.yml
@@ -1,0 +1,25 @@
+$schema: https://raw.githubusercontent.com/CodSpeedHQ/codspeed/refs/heads/main/schemas/codspeed.schema.json
+
+options:
+  warmup-time: 0s
+  min-rounds: 30
+  max-rounds: 100
+
+benchmarks:
+  - name: python startup
+    exec: .venv/bin/python -c "pass"
+
+  - name: import pytest
+    exec: .venv/bin/python -c "import pytest"
+
+  - name: import pluggy
+    exec: .venv/bin/python -c "import pluggy"
+
+  - name: import rich
+    exec: .venv/bin/python -c "import rich"
+
+  - name: import pytest_codspeed
+    exec: .venv/bin/python -c "import pytest_codspeed"
+
+  - name: import pytest_codspeed.plugin
+    exec: .venv/bin/python -c "import pytest_codspeed.plugin"


### PR DESCRIPTION
Add a dedicated CodSpeed CLI config for measuring import time in pytest-codspeed.

The new config benchmarks Python startup plus imports for pytest, pluggy, rich, pytest_codspeed, and pytest_codspeed.plugin. The workflow runs these import benchmarks in both simulation and walltime, using the explicit codspeed-import-time.yml config so it stays separate from the existing pytest benchmark suite.

Local walltime ran successfully and uploaded results: https://codspeed.io/CodSpeedHQ/pytest-codspeed/runs/6a19a2aa8971b07951a0c99d

Local simulation could not run on macOS because the Valgrind executor is not supported there; the CI job runs simulation on Ubuntu.