### PR TITLE
fix(walltime): normalize minimum time only once

### DIFF
--- a/src/pytest_codspeed/instruments/walltime.py
+++ b/src/pytest_codspeed/instruments/walltime.py
@@ -380,7 +380,7 @@ class WallTimeInstrument(Instrument):
                 rsd_text.stylize("red bold")
             table.add_row(
                 escape(bench.name),
-                format_time(bench.stats.min_ns / bench.stats.iter_per_round),
+                format_time(bench.stats.min_ns),
                 rsd_text,
                 f"{bench.stats.total_time:,.2f}s",
                 f"{bench.stats.iter_per_round * bench.stats.rounds:,}",


### PR DESCRIPTION
In the local walltime mode results table, the "Time (best)" column divides by `iter_per_round` twice: once in `BenchmarkStats.from_list`, and again in `_print_benchmark_table`.

This is only an issue for fast benchmarks: since `iter_per_round` defaults to 1ms, the time for benchmarks taking more than 1ms get divided by 1 twice.

# MRE

`repro.py`: 

```python
import time


def test_sleep_100us(benchmark):
    benchmark(time.sleep, 0.0001)


def test_sleep_5ms(benchmark):
    benchmark(time.sleep, 0.005)
```

```bash
# pytest-benchmark correctly displays ~100us for for the 100us test and ~5000us for the 5ms test
❯ uv run pytest bench_repro.py

[...]


---------------------------------------------------------------------------------------- benchmark: 2 tests ----------------------------------------------------------------------------------------
Name (time in us)            Min                   Max                  Mean            StdDev                Median               IQR            Outliers         OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_sleep_100us        100.8900 (1.0)        130.8170 (1.0)        101.8938 (1.0)      1.8603 (1.0)        101.5320 (1.0)      0.6710 (1.0)       336;434  9,814.1441 (1.0)        8908           1
test_sleep_5ms        5,002.3020 (49.58)    5,064.6200 (38.72)    5,015.6336 (49.22)    6.9418 (3.73)     5,016.1335 (49.40)    1.3230 (1.97)        37;50    199.3766 (0.02)        200           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

# pytest-codspeed is correct for the 5ms test, but displays only 10us for the 100us test
❯ uv run pytest bench_repro.py --codspeed

[...]

                         Benchmark Results                          
┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┓
┃        Benchmark ┃ Time (best) ┃ Rel. StdDev ┃ Run time ┃  Iters ┃
┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
│ test_sleep_100us │     10.11µs │        1.4% │    3.00s │ 29,410 │
│   test_sleep_5ms │       5.0ms │        1.3% │    3.00s │    596 │


