### PR TITLE
docs(readme): bump action version to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@v5
         with:
           mode: simulation # or `walltime`
           token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
`CodSpeedHQ/action` v5.0.0 is out, so the README workflow example now points at it.

Refs COD-3244 (kept open, it tracks the runner release itself)
